### PR TITLE
View interesting unread messages by clicking on the mode-line indicator

### DIFF
--- a/mu4e-alert.el
+++ b/mu4e-alert.el
@@ -171,7 +171,7 @@ MAIL-COUNT is the count of mails for which the string is to displayed"
 This is primarily used to enable viewing unread emails by default mode-line
 formatter when user clicks on mode-line indicator"
   (interactive)
-  (mu4e-headers-search "flag:unread AND NOT flag:trashed"))
+  (mu4e-headers-search mu4e-alert-interesting-mail-query))
 
 (defun mu4e-alert-update-mail-count-modeline ()
   "Update mail count in the mode-line."


### PR DESCRIPTION
Thank you for this package!

I think it makes more sense to show the same messages that the notifications are interested in.

This makes the click on the mode-line indicator use the `mu4e-alert-interesting-mail-query`-variable as a query. This is the same query the notifications use to check if there is unread mail.
