### PR TITLE
Add option to always show the default mode-line indicator.

### DIFF
--- a/mu4e-alert.el
+++ b/mu4e-alert.el
@@ -292,10 +292,13 @@ CALLBACK is called with one argument the interesting emails."
 
 (defvar mu4e-alert-mode-line nil "The mode-line indicator to display the count of unread emails.")
 
+(defvar mu4e-alert-default-mode-line-always-display nil "Should the default mode-line indicator always be displayed, even if there are zero unread emails?")
+
 (defun mu4e-alert-default-mode-line-formatter (mail-count)
   "Default formatter used to get the string to be displayed in the mode-line.
 MAIL-COUNT is the count of mails for which the string is to displayed"
-  (when (not (zerop mail-count))
+  (when (or (not (zerop mail-count))
+            mu4e-alert-default-mode-line-always-display)
     (concat " "
             (propertize
              "Mail"

--- a/mu4e-alert.el
+++ b/mu4e-alert.el
@@ -315,9 +315,7 @@ MAIL-COUNT is the count of mails for which the string is to displayed"
                                  (mouse-1 . mu4e-alert-view-unread-mails)
                                  (mouse-2 . mu4e-alert-view-unread-mails)
                                  (mouse-3 . mu4e-alert-view-unread-mails)))
-            (if (zerop mail-count)
-                " "
-              (format " [%d] " mail-count)))))
+            (format " [%d] " mail-count))))
 
 (defun mu4e-alert-view-unread-mails ()
   "View unread mails.


### PR DESCRIPTION
Currently there is no way, with the default mode-line indicator, to configure it to always show itself even when you have zero unread emails. I added a variable `mu4e-alert-default-mode-line-always-display` that when non-nil will cause the mode-line indicator to be displayed even if there are zero unread emails.