### PR TITLE
Use updated variable name `mu4e--context-current` from mu4e

### DIFF
--- a/mu4e-alert.el
+++ b/mu4e-alert.el
@@ -521,9 +521,9 @@ ALL-MAILS are the all the unread emails"
 
 (defadvice mu4e-context-switch (around mu4e-alert-update-mail-count-modeline disable)
   "Advice `mu4e-context-switch' to update mode-line after changing the context."
-  (let ((context mu4e~context-current))
+  (let ((context mu4e--context-current))
     ad-do-it
-    (unless (equal context mu4e~context-current)
+    (unless (equal context mu4e--context-current)
       (mu4e-alert-update-mail-count-modeline))))
 
 ;;;###autoload


### PR DESCRIPTION
### Issue

- `mu4e~context-current` has been renamed to `mu4e--context-current` in [mu4e commit 035977](
https://github.com/djcb/mu/commit/035977a89ae04d99892b3382582ec5b0b8b6a140#diff-054cae5f4ab3d0833d62925915cb4d09a0521ac46332447c97d50c1da3af0483)
- `mu4e-alert` was using the older `mu4e~context-current` name for the variable

### Fix

- Use variable name `mu4e--context-current` instead of `mu4e~context-current` in `mu4e-alert`